### PR TITLE
Update Dockerfile to 3.11-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-alpine
 
 ENV HOST=0.0.0.0
  


### PR DESCRIPTION
3.11-alpine to reduce Artiifact regisstry image size from 700MB to 5 MB