### PR TITLE
3.11-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-alpine
 
 ENV HOST=0.0.0.0
  


### PR DESCRIPTION
used 3.11-alpine nsead of he bullseye, to reduce artifact image size, to bring down cloud cost to 0